### PR TITLE
Fixes issue #4 thread lock in test_backend using masterkeys.py

### DIFF
--- a/rgbkeyboards/windows/masterkeys/masterkeys.py
+++ b/rgbkeyboards/windows/masterkeys/masterkeys.py
@@ -104,7 +104,7 @@ class Keyboard(BaseKeyboard):
 
     def _set_control_device(self):
         """Select the first encountered keyboard for control"""
-        available_dev = self.get_device_available(True)
+        available_dev = self._get_device_available(True)
         if available_dev is None:
             return False
         r = self.library.SetControlDevice(available_dev)


### PR DESCRIPTION
Fixes the `Keyboard.get_device_available` thread lock issue on masterkeys.py. #4 